### PR TITLE
Fix Stockfish integration

### DIFF
--- a/src/components/PlayComputer/ChessBoard.jsx
+++ b/src/components/PlayComputer/ChessBoard.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Chess } from "chess.js";
 import { motion } from "framer-motion";
-import stockfish from "stockfish.wasm";
+import createStockfish from "../../utils/stockfishLoader";
 
 function ChessBoard({ stockfishLevel, gameStarted }) {
   const [game] = useState(new Chess());
@@ -21,8 +21,8 @@ function ChessBoard({ stockfishLevel, gameStarted }) {
   useEffect(() => {
     if (!gameStarted) return;
 
-    // stockfish.wasm returns a Web Worker that runs the engine
-    stockfishRef.current = stockfish();
+    // create the Stockfish Web Worker from public/stockfish
+    stockfishRef.current = createStockfish();
     stockfishRef.current.postMessage("uci");
 
     const onMessage = (e) => {
@@ -36,9 +36,6 @@ function ChessBoard({ stockfishLevel, gameStarted }) {
         setEngineReady(true);
         addLog("Engine pronta.");
 
-        // Teste manual
-        stockfishRef.current.postMessage("position startpos");
-        stockfishRef.current.postMessage("go depth 10");
       } else if (msg.startsWith("bestmove")) {
         const move = msg.split(" ")[1];
         if (move && move !== "(none)") {

--- a/src/utils/stockfishLoader.js
+++ b/src/utils/stockfishLoader.js
@@ -1,0 +1,10 @@
+export default function createStockfish() {
+  try {
+    // Worker is served from public/stockfish
+    const workerUrl = new URL('/stockfish/stockfish.js', import.meta.url);
+    return new Worker(workerUrl);
+  } catch (err) {
+    console.error('Failed to load Stockfish worker', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- load Stockfish from `/public/stockfish` using a helper
- wire up engine worker in `ChessBoard` component

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68853140cccc83319365aed76999ebf3